### PR TITLE
Add OCR-based PDF renaming app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# PDF Renamer with OCR
+
+This project provides a simple Flask web interface to rename scanned PDF drawings based on text extracted with OpenAI's GPT-4o Vision API. For every processed PDF an image of the first page, the OCR text and the renamed file are saved in the `output` folder. A history of generated files is also kept.
+
+## Requirements
+- Python 3.11+
+- `pip`
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Running the application
+1. Copy `.env.example` to `.env` and fill in your OpenAI API key.
+2. Start the Flask server:
+```bash
+python -m src.app
+```
+3. Open `http://localhost:5000` in your browser.
+
+## Features
+- Upload a single PDF or provide a folder containing PDFs.
+- OCR text extraction using OpenAI 4o Vision API.
+- Generated image and text are displayed in the UI.
+- Proposed file name based on OCR text is shown and saved.
+- History page shows all processed PDFs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+python-dotenv
+openai
+pdf2image
+Pillow

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["create_app"]
+
+from .app import create_app

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from datetime import datetime
+import json
+from typing import Optional, List
+
+from flask import Flask, render_template, request, redirect, url_for, send_from_directory
+from werkzeug.utils import secure_filename
+from dotenv import load_dotenv
+
+from .ocr import pdf_first_page_to_image, ocr_image, sanitize_filename
+from .utils import save_history, HISTORY_FILE
+
+load_dotenv()
+
+
+ALLOWED_EXTENSIONS = {"pdf"}
+OUTPUT_DIR = Path("output")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        return render_template("index.html")
+
+    @app.route("/process", methods=["POST"])
+    def process():
+        folder = request.form.get("folder")
+        files: List[Path] = []
+        if folder:
+            files = [Path(folder) / f for f in Path(folder).glob("*.pdf")]
+        if "file" in request.files and request.files["file"].filename:
+            file = request.files["file"]
+            if file and allowed_file(file.filename):
+                filename = secure_filename(file.filename)
+                upload_path = OUTPUT_DIR / filename
+                file.save(upload_path)
+                files.append(upload_path)
+        results = []
+        for pdf_path in files:
+            image = pdf_first_page_to_image(str(pdf_path))
+            text = ocr_image(image)
+            base_name = sanitize_filename(text)
+            image_path = OUTPUT_DIR / f"{base_name}.png"
+            text_path = OUTPUT_DIR / f"{base_name}.txt"
+            pdf_new_path = OUTPUT_DIR / f"{base_name}.pdf"
+            image.save(image_path)
+            text_path.write_text(text)
+            shutil.copy(pdf_path, pdf_new_path)
+            save_history({
+                "time": datetime.utcnow().isoformat(),
+                "original": str(pdf_path),
+                "pdf": str(pdf_new_path),
+                "image": str(image_path),
+                "text": str(text_path),
+            })
+            results.append({
+                "image": image_path.name,
+                "text": text,
+                "pdf": pdf_new_path.name,
+            })
+        return render_template("index.html", results=results)
+
+    @app.route("/history")
+    def history():
+        entries = []
+        if HISTORY_FILE.exists():
+            entries = json.loads(HISTORY_FILE.read_text())[::-1]
+        return render_template("history.html", entries=entries)
+
+    @app.route('/output/<path:filename>')
+    def output_files(filename):
+        return send_from_directory(OUTPUT_DIR, filename)
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(debug=True)

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,0 +1,55 @@
+import base64
+import os
+from io import BytesIO
+from typing import Tuple
+
+from pdf2image import convert_from_path
+from PIL import Image
+import openai
+
+
+def pdf_first_page_to_image(pdf_path: str) -> Image.Image:
+    """Convert the first page of a PDF to a PIL image."""
+    images = convert_from_path(pdf_path, first_page=1, last_page=1)
+    return images[0]
+
+
+def ocr_image(image: Image.Image) -> str:
+    """Use OpenAI GPT-4o Vision to extract text from an image."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    buffered = BytesIO()
+    image.save(buffered, format="PNG")
+    img_b64 = base64.b64encode(buffered.getvalue()).decode()
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{img_b64}"},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Extract the drawing number or title for renaming",
+                    },
+                ],
+            }
+        ],
+        max_tokens=50,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def sanitize_filename(text: str) -> str:
+    """Sanitize text for use as a filename."""
+    import re
+
+    name = re.sub(r"[^0-9a-zA-Z_-]+", "_", text.strip())
+    return name[:50] or "document"

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>History</title>
+</head>
+<body>
+  <h1>Processed PDFs</h1>
+  <p><a href="/">Back</a></p>
+  <ul>
+    {% for item in entries %}
+      <li>
+        {{ item.time }} - <a href="/output/{{ item.pdf }}">{{ item.pdf }}</a>
+        (<a href="/output/{{ item.image }}">image</a>,
+         <a href="/output/{{ item.text }}">text</a>)
+      </li>
+    {% endfor %}
+  </ul>
+</body>
+</html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PDF Renamer</title>
+</head>
+<body>
+  <h1>PDF Renamer with OCR</h1>
+  <form action="/process" method="post" enctype="multipart/form-data">
+    <label>Upload PDF:</label>
+    <input type="file" name="file" accept="application/pdf"><br>
+    <label>Or folder path on server:</label>
+    <input type="text" name="folder" placeholder="/path/to/folder"><br>
+    <button type="submit">Process</button>
+  </form>
+  <p><a href="/history">History</a></p>
+
+  {% if results %}
+    <h2>Results</h2>
+    {% for r in results %}
+      <div style="margin-bottom:20px;">
+        <p><strong>Proposed name:</strong> {{ r.pdf }}</p>
+        <img src="/output/{{ r.image }}" width="300"><br>
+        <pre>{{ r.text }}</pre>
+        <a href="/output/{{ r.pdf }}">Download PDF</a>
+      </div>
+    {% endfor %}
+  {% endif %}
+</body>
+</html>

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Dict
+
+HISTORY_FILE = Path("output/history.json")
+HISTORY_FILE.parent.mkdir(exist_ok=True)
+
+
+def save_history(entry: Dict) -> None:
+    data = []
+    if HISTORY_FILE.exists():
+        data = json.loads(HISTORY_FILE.read_text())
+    data.append(entry)
+    HISTORY_FILE.write_text(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- implement simple Flask app to rename PDFs using GPT‑4o OCR
- add OCR utilities
- store history of processed PDFs
- provide minimal HTML pages and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851140b580c832e909ba249cbbf71e6